### PR TITLE
feat: marketplace readiness — tool annotations + OAuth 2.1 layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,16 @@ PORT=3011
 
 # Meeting BaaS base domain for API URL (Without protocol or leading dot)
 BAAS_URL=meetingbaas.com
+
+# --- OAuth (marketplace clients: ChatGPT Apps, Claude connectors) ---
+# Public base URL of this server (defaults to https://mcp.meetingbaas.com)
+OAUTH_ISSUER=
+# Meeting BaaS dashboard consent page; /oauth/authorize redirects here with
+# ?request_id=...&client_name=...&scope=... After login+approval the dashboard
+# backend POSTs /oauth/consent/complete with the shared secret below.
+OAUTH_CONSENT_URL=
+# Shared secret authenticating the dashboard -> /oauth/consent/complete call
+OAUTH_CONSENT_SECRET=
+# Optional token lifetime overrides (seconds)
+OAUTH_ACCESS_TOKEN_TTL_S=
+OAUTH_REFRESH_TOKEN_TTL_S=

--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,5 @@ OAUTH_CONSENT_SECRET=
 # Optional token lifetime overrides (seconds)
 OAUTH_ACCESS_TOKEN_TTL_S=
 OAUTH_REFRESH_TOKEN_TTL_S=
+# CA certificate for managed Redis over TLS (rediss:// URLs), optional
+REDIS_CA_CERT_PATH=

--- a/api/server.ts
+++ b/api/server.ts
@@ -193,12 +193,6 @@ const handler = initializeMcpApiHandler(
           description: "Get a meeting transcript as a readable dialog or full JSON with metadata.",
           category: "AI Agent Tools",
           apiVersion: "v2"
-        },
-
-        // Utility Category
-        echo: {
-          description: "Echo a message back.",
-          category: "Utility"
         }
       }
     }

--- a/api/tools-v1.ts
+++ b/api/tools-v1.ts
@@ -21,10 +21,15 @@ export function registerV1Tools(server: McpServer, apiKey: string, baseUrl?: str
   })
 
   // For Join Meeting
-  server.tool(
+  server.registerTool(
     "joinMeeting",
-    "Send an AI bot to join a video meeting. The bot can record the meeting, transcribe speech (enabled by default using Gladia), and provide real-time audio streams. Use this when you want to: 1) Record a meeting 2) Get meeting transcriptions 3) Stream meeting audio 4) Monitor meeting attendance",
-    joinBody.shape,
+    {
+      title: "Join Meeting",
+      description:
+        "Send an AI bot to join a video meeting. The bot can record the meeting, transcribe speech (enabled by default using Gladia), and provide real-time audio streams. Use this when you want to: 1) Record a meeting 2) Get meeting transcriptions 3) Stream meeting audio 4) Monitor meeting attendance",
+      inputSchema: joinBody.shape,
+      annotations: { openWorldHint: true, destructiveHint: false }
+    },
     async (args) => {
       console.log("Attempting to join meeting", redactArgs(args))
       try {
@@ -53,10 +58,15 @@ export function registerV1Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // For Leave Meeting
-  server.tool(
+  server.registerTool(
     "leaveMeeting",
-    "Remove an AI bot from a meeting. Use this when you want to: 1) End a meeting recording 2) Stop transcription 3) Disconnect the bot from the meeting",
-    { bot_id: z.string() },
+    {
+      title: "Leave Meeting",
+      description:
+        "Remove an AI bot from a meeting. Use this when you want to: 1) End a meeting recording 2) Stop transcription 3) Disconnect the bot from the meeting",
+      inputSchema: { bot_id: z.string() },
+      annotations: { destructiveHint: true, idempotentHint: true }
+    },
     async (args) => {
       const { bot_id } = args
       console.log(`Attempting to remove bot ${bot_id} from meeting`)
@@ -88,10 +98,15 @@ export function registerV1Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // For Get Meeting Data
-  server.tool(
+  server.registerTool(
     "getMeetingData",
-    "Get data about a meeting that a bot has joined. Use this when you want to: 1) Check meeting status 2) Get recording information 3) Access transcription data",
-    getMeetingDataQueryParams.shape,
+    {
+      title: "Get Meeting Data",
+      description:
+        "Get data about a meeting that a bot has joined. Use this when you want to: 1) Check meeting status 2) Get recording information 3) Access transcription data",
+      inputSchema: getMeetingDataQueryParams.shape,
+      annotations: { readOnlyHint: true }
+    },
     async (args) => {
       console.log("Attempting to get meeting data", redactArgs(args))
       const { data, success, error } = await baasClient.getMeetingData(args)
@@ -121,10 +136,15 @@ export function registerV1Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // For Delete Data
-  server.tool(
+  server.registerTool(
     "deleteData",
-    "Delete data associated with a meeting bot. Use this when you want to: 1) Remove meeting recordings 2) Delete transcription data 3) Clean up bot data",
-    { bot_id: z.string() },
+    {
+      title: "Delete Bot Data",
+      description:
+        "Delete data associated with a meeting bot. Use this when you want to: 1) Remove meeting recordings 2) Delete transcription data 3) Clean up bot data",
+      inputSchema: { bot_id: z.string() },
+      annotations: { destructiveHint: true, idempotentHint: true }
+    },
     async (args) => {
       const { bot_id } = args
       console.log("Attempting to delete meeting data", redactArgs(args))
@@ -155,10 +175,15 @@ export function registerV1Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // For Re-Transcribe Bot
-  server.tool(
+  server.registerTool(
     "retranscribeBot",
-    "Transcribe or retranscribe a bot recording using the Default or provided Speech to Text Provider. Use this when you want to: 1) Transcribe a bot recording 2) Retranscribe if you want to improve the transcription",
-    retranscribeBotBody.shape,
+    {
+      title: "Retranscribe Bot",
+      description:
+        "Transcribe or retranscribe a bot recording using the Default or provided Speech to Text Provider. Use this when you want to: 1) Transcribe a bot recording 2) Retranscribe if you want to improve the transcription",
+      inputSchema: retranscribeBotBody.shape,
+      annotations: { destructiveHint: false }
+    },
     async (args) => {
       console.log("Attempting to retranscribe bot", redactArgs(args))
       const { data, success, error } = await baasClient.retranscribeBot(args)
@@ -188,10 +213,15 @@ export function registerV1Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // For Create Calendar
-  server.tool(
+  server.registerTool(
     "createCalendar",
-    "Create a new calendar integration. Use this when you want to: 1) Set up automatic meeting recordings 2) Configure calendar-based bot scheduling 3) Enable recurring meeting coverage",
-    createCalendarBody.shape,
+    {
+      title: "Create Calendar",
+      description:
+        "Create a new calendar integration. Use this when you want to: 1) Set up automatic meeting recordings 2) Configure calendar-based bot scheduling 3) Enable recurring meeting coverage",
+      inputSchema: createCalendarBody.shape,
+      annotations: { destructiveHint: false }
+    },
     async (args) => {
       console.log("Attempting to create calendar", redactArgs(args))
       const { data, success, error } = await baasClient.createCalendar(args)
@@ -221,10 +251,15 @@ export function registerV1Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // For List Calendar
-  server.tool(
+  server.registerTool(
     "listCalendars",
-    "List all calendar integrations. Use this when you want to: 1) View configured calendars 2) Check calendar status 3) Manage calendar integrations",
-    {},
+    {
+      title: "List Calendars",
+      description:
+        "List all calendar integrations. Use this when you want to: 1) View configured calendars 2) Check calendar status 3) Manage calendar integrations",
+      inputSchema: {},
+      annotations: { readOnlyHint: true }
+    },
     async () => {
       console.log("Attempting to list calendars")
       const { data, success, error } = await baasClient.listCalendars()
@@ -254,10 +289,15 @@ export function registerV1Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // For Get Calendar
-  server.tool(
+  server.registerTool(
     "getCalendar",
-    "Get details about a specific calendar integration. Use this when you want to: 1) View calendar configuration 2) Check calendar status 3) Verify calendar settings",
-    { calendar_id: z.string() },
+    {
+      title: "Get Calendar",
+      description:
+        "Get details about a specific calendar integration. Use this when you want to: 1) View calendar configuration 2) Check calendar status 3) Verify calendar settings",
+      inputSchema: { calendar_id: z.string() },
+      annotations: { readOnlyHint: true }
+    },
     async (args) => {
       const { calendar_id } = args
       console.log("Attempting to get calendar", redactArgs(args))
@@ -288,10 +328,15 @@ export function registerV1Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // For delete Calendar
-  server.tool(
+  server.registerTool(
     "deleteCalendar",
-    "Delete a calendar integration. Use this when you want to: 1) Remove a calendar connection 2) Stop automatic recordings 3) Clean up calendar data",
-    { calendar_id: z.string() },
+    {
+      title: "Delete Calendar",
+      description:
+        "Delete a calendar integration. Use this when you want to: 1) Remove a calendar connection 2) Stop automatic recordings 3) Clean up calendar data",
+      inputSchema: { calendar_id: z.string() },
+      annotations: { destructiveHint: true, idempotentHint: true }
+    },
     async (args) => {
       const { calendar_id } = args
       console.log("Attempting to delete calendar", redactArgs(args))
@@ -322,10 +367,15 @@ export function registerV1Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // For Bots with meta data
-  server.tool(
+  server.registerTool(
     "botsWithMetadata",
-    "Get a list of all bots with their metadata. Use this when you want to: 1) View active bots 2) Check bot status 3) Monitor bot activity",
-    botsWithMetadataQueryParams.shape,
+    {
+      title: "List Bots With Metadata",
+      description:
+        "Get a list of all bots with their metadata. Use this when you want to: 1) View active bots 2) Check bot status 3) Monitor bot activity",
+      inputSchema: botsWithMetadataQueryParams.shape,
+      annotations: { readOnlyHint: true }
+    },
     async (args) => {
       console.log("Attempting to get bots with metadata", redactArgs(args))
       const { data, success, error } = await baasClient.listBots(args)
@@ -355,10 +405,15 @@ export function registerV1Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // For List All Events
-  server.tool(
+  server.registerTool(
     "listEvents",
-    "List all scheduled events. Use this when you want to: 1) View upcoming recordings 2) Check scheduled transcriptions 3) Monitor planned bot activity",
-    listEventsQueryParams.shape,
+    {
+      title: "List Events",
+      description:
+        "List all scheduled events. Use this when you want to: 1) View upcoming recordings 2) Check scheduled transcriptions 3) Monitor planned bot activity",
+      inputSchema: listEventsQueryParams.shape,
+      annotations: { readOnlyHint: true }
+    },
     async (args) => {
       console.log("Attempting to list events", redactArgs(args))
       const { data, success, error } = await baasClient.listCalendarEvents(args)
@@ -388,13 +443,18 @@ export function registerV1Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // For Schedule Record Events
-  server.tool(
+  server.registerTool(
     "scheduleRecordEvent",
-    "Schedule a recording. Use this when you want to: 1) Set up automatic recording 2) Schedule future transcriptions 3) Plan meeting recordings",
     {
-      calendar_id: z.string(),
-      all_occurrences: z.boolean().optional(),
-      ...scheduleRecordEventBody.shape
+      title: "Schedule Record Event",
+      description:
+        "Schedule a recording. Use this when you want to: 1) Set up automatic recording 2) Schedule future transcriptions 3) Plan meeting recordings",
+      inputSchema: {
+        calendar_id: z.string(),
+        all_occurrences: z.boolean().optional(),
+        ...scheduleRecordEventBody.shape
+      },
+      annotations: { destructiveHint: false }
     },
     async (args) => {
       const { calendar_id, all_occurrences, ...body } = args
@@ -433,12 +493,17 @@ export function registerV1Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // For Un-Schedule Record Events
-  server.tool(
+  server.registerTool(
     "unscheduleRecordEvent",
-    "Cancel a scheduled recording. Use this when you want to: 1) Cancel automatic recording 2) Stop planned transcription 3) Remove scheduled bot activity",
     {
-      event_uuid: z.string(),
-      all_occurrences: z.boolean().optional()
+      title: "Unschedule Record Event",
+      description:
+        "Cancel a scheduled recording. Use this when you want to: 1) Cancel automatic recording 2) Stop planned transcription 3) Remove scheduled bot activity",
+      inputSchema: {
+        event_uuid: z.string(),
+        all_occurrences: z.boolean().optional()
+      },
+      annotations: { destructiveHint: true, idempotentHint: true }
     },
     async (args) => {
       const { event_uuid, all_occurrences } = args
@@ -473,12 +538,17 @@ export function registerV1Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // For Update Calendar
-  server.tool(
+  server.registerTool(
     "updateCalendar",
-    "Update a calendar integration configuration. Use this when you want to: 1) Modify calendar settings 2) Update connection details 3) Change calendar configuration",
     {
-      calendar_id: z.string(),
-      ...updateCalendarBody.shape
+      title: "Update Calendar",
+      description:
+        "Update a calendar integration configuration. Use this when you want to: 1) Modify calendar settings 2) Update connection details 3) Change calendar configuration",
+      inputSchema: {
+        calendar_id: z.string(),
+        ...updateCalendarBody.shape
+      },
+      annotations: { destructiveHint: false }
     },
     async (args) => {
       const { calendar_id, ...body } = args
@@ -511,16 +581,6 @@ export function registerV1Tools(server: McpServer, apiKey: string, baseUrl?: str
       }
     }
   )
-
-  // Add echo tool for testing
-  server.tool("echo", { message: z.string() }, async ({ message }: { message: string }) => ({
-    content: [
-      {
-        type: "text",
-        text: `Tool echo: ${message}`
-      }
-    ]
-  }))
 
   return server
 }

--- a/api/tools-v2.ts
+++ b/api/tools-v2.ts
@@ -184,10 +184,14 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   // --- Bot Management ---
 
   // Create Bot (equivalent to v1 joinMeeting)
-  server.tool(
+  server.registerTool(
     "createBot",
-    "Create and send an AI bot to join a video meeting. The bot can record the meeting, transcribe speech (enabled by default using the Gladia provider), and provide real-time audio streams. Use this when you want to: 1) Record a meeting 2) Get meeting transcriptions 3) Stream meeting audio 4) Monitor meeting attendance",
-    botConfigShape,
+    {
+      title: "Create Bot",
+      description: "Create and send an AI bot to join a video meeting. The bot can record the meeting, transcribe speech (enabled by default using the Gladia provider), and provide real-time audio streams. Use this when you want to: 1) Record a meeting 2) Get meeting transcriptions 3) Stream meeting audio 4) Monitor meeting attendance",
+      inputSchema: botConfigShape,
+      annotations: { openWorldHint: true, destructiveHint: false }
+    },
     async (args) => {
       console.log("Attempting to create bot", redactArgs(args))
       const result = await baasClient.createBot(withTranscriptionDefaults(args))
@@ -206,10 +210,14 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // List Bots (equivalent to v1 botsWithMetadata)
-  server.tool(
+  server.registerTool(
     "listBots",
-    "Get a list of all bots with their metadata. Use this when you want to: 1) View active bots 2) Check bot status 3) Monitor bot activity",
-    V2Zod.listBotsQueryParams.shape,
+    {
+      title: "List Bots",
+      description: "Get a list of all bots with their metadata. Use this when you want to: 1) View active bots 2) Check bot status 3) Monitor bot activity",
+      inputSchema: V2Zod.listBotsQueryParams.shape,
+      annotations: { readOnlyHint: true }
+    },
     async (args) => {
       console.log("Attempting to list bots", redactArgs(args))
       const result = await baasClient.listBots(args)
@@ -227,10 +235,14 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Get Bot Details (equivalent to v1 getMeetingData)
-  server.tool(
+  server.registerTool(
     "getBotDetails",
-    "Get detailed information about a specific bot including recording data and transcripts. Use this when you want to: 1) Check meeting status 2) Get recording information 3) Access transcription data",
-    { bot_id: z.string() },
+    {
+      title: "Get Bot Details",
+      description: "Get detailed information about a specific bot including recording data and transcripts. Use this when you want to: 1) Check meeting status 2) Get recording information 3) Access transcription data",
+      inputSchema: { bot_id: z.string() },
+      annotations: { readOnlyHint: true }
+    },
     async (args) => {
       console.log("Attempting to get bot details", redactArgs(args))
       const result = await baasClient.getBotDetails({ bot_id: args.bot_id })
@@ -248,10 +260,14 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Get Bot Status
-  server.tool(
+  server.registerTool(
     "getBotStatus",
-    "Get the current status of a bot. Use this when you want to: 1) Check if a bot is still in a meeting 2) Monitor bot connection status 3) Get real-time bot state",
-    { bot_id: z.string() },
+    {
+      title: "Get Bot Status",
+      description: "Get the current status of a bot. Use this when you want to: 1) Check if a bot is still in a meeting 2) Monitor bot connection status 3) Get real-time bot state",
+      inputSchema: { bot_id: z.string() },
+      annotations: { readOnlyHint: true }
+    },
     async (args) => {
       console.log("Attempting to get bot status", redactArgs(args))
       const result = await baasClient.getBotStatus({ bot_id: args.bot_id })
@@ -269,10 +285,14 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Leave Bot (equivalent to v1 leaveMeeting)
-  server.tool(
+  server.registerTool(
     "leaveBot",
-    "Remove an AI bot from a meeting. Use this when you want to: 1) End a meeting recording 2) Stop transcription 3) Disconnect the bot from the meeting",
-    { bot_id: z.string() },
+    {
+      title: "Leave Bot",
+      description: "Remove an AI bot from a meeting. Use this when you want to: 1) End a meeting recording 2) Stop transcription 3) Disconnect the bot from the meeting",
+      inputSchema: { bot_id: z.string() },
+      annotations: { destructiveHint: true, idempotentHint: true }
+    },
     async (args) => {
       console.log(`Attempting to remove bot ${args.bot_id} from meeting`)
       const result = await baasClient.leaveBot({ bot_id: args.bot_id })
@@ -291,12 +311,16 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Delete Bot Data (equivalent to v1 deleteData)
-  server.tool(
+  server.registerTool(
     "deleteBotData",
-    "Delete data associated with a meeting bot. Use this when you want to: 1) Remove meeting recordings 2) Delete transcription data 3) Clean up bot data",
     {
-      bot_id: z.string(),
-      delete_from_provider: z.boolean().optional()
+      title: "Delete Bot Data",
+      description: "Delete data associated with a meeting bot. Use this when you want to: 1) Remove meeting recordings 2) Delete transcription data 3) Clean up bot data",
+      inputSchema: {
+        bot_id: z.string(),
+        delete_from_provider: z.boolean().optional()
+      },
+      annotations: { destructiveHint: true, idempotentHint: true }
     },
     async (args) => {
       console.log("Attempting to delete bot data", redactArgs(args))
@@ -315,10 +339,14 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Batch Create Bots
-  server.tool(
+  server.registerTool(
     "batchCreateBots",
-    "Create multiple bots in a single request. Use this when you want to: 1) Send bots to several meetings at once 2) Bulk-record a set of meetings 3) Reduce round-trips when scheduling many bots",
-    { bots: z.array(z.object(botConfigShape)).min(1).describe("Array of bot configurations to create") },
+    {
+      title: "Batch Create Bots",
+      description: "Create multiple bots in a single request. Use this when you want to: 1) Send bots to several meetings at once 2) Bulk-record a set of meetings 3) Reduce round-trips when scheduling many bots",
+      inputSchema: { bots: z.array(z.object(botConfigShape)).min(1).describe("Array of bot configurations to create") },
+      annotations: { openWorldHint: true, destructiveHint: false }
+    },
     async (args) => {
       console.log("Attempting to batch create bots", { count: args.bots.length })
       const result = await baasClient.batchCreateBots(args.bots.map(withTranscriptionDefaults))
@@ -336,13 +364,17 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Get Bot Screenshots
-  server.tool(
+  server.registerTool(
     "getBotScreenshots",
-    "Get screenshots captured during a bot session. Use this when you want to: 1) Verify what the bot saw in the meeting 2) Inspect the meeting visually 3) Debug a recording",
     {
-      bot_id: z.string(),
-      limit: z.number().optional(),
-      cursor: z.string().optional()
+      title: "Get Bot Screenshots",
+      description: "Get screenshots captured during a bot session. Use this when you want to: 1) Verify what the bot saw in the meeting 2) Inspect the meeting visually 3) Debug a recording",
+      inputSchema: {
+        bot_id: z.string(),
+        limit: z.number().optional(),
+        cursor: z.string().optional()
+      },
+      annotations: { readOnlyHint: true }
     },
     async (args) => {
       console.log("Attempting to get bot screenshots", redactArgs(args))
@@ -361,10 +393,14 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Resend Final Webhook
-  server.tool(
+  server.registerTool(
     "resendFinalWebhook",
-    "Resend the final webhook for a completed bot. Use this when you want to: 1) Recover from a missed webhook 2) Re-trigger downstream processing 3) Replay the end-of-meeting notification",
-    { bot_id: z.string() },
+    {
+      title: "Resend Final Webhook",
+      description: "Resend the final webhook for a completed bot. Use this when you want to: 1) Recover from a missed webhook 2) Re-trigger downstream processing 3) Replay the end-of-meeting notification",
+      inputSchema: { bot_id: z.string() },
+      annotations: { destructiveHint: false }
+    },
     async (args) => {
       console.log("Attempting to resend final webhook", redactArgs(args))
       const result = await baasClient.resendFinalWebhook({ bot_id: args.bot_id })
@@ -382,12 +418,16 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Retry Callback
-  server.tool(
+  server.registerTool(
     "retryCallback",
-    "Retry the callback for a bot, optionally overriding the callback configuration. Use this when you want to: 1) Re-deliver a failed callback 2) Point a callback at a new URL 3) Recover from a callback outage",
     {
-      bot_id: z.string(),
-      callback_config: callbackConfigSchema
+      title: "Retry Callback",
+      description: "Retry the callback for a bot, optionally overriding the callback configuration. Use this when you want to: 1) Re-deliver a failed callback 2) Point a callback at a new URL 3) Recover from a callback outage",
+      inputSchema: {
+        bot_id: z.string(),
+        callback_config: callbackConfigSchema
+      },
+      annotations: { destructiveHint: false }
     },
     async (args) => {
       console.log("Attempting to retry callback", redactArgs(args))
@@ -406,12 +446,16 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Update Bot Config
-  server.tool(
+  server.registerTool(
     "updateBotConfig",
-    "Update a running bot's extra metadata (shallow-merged with existing data). Use this when you want to: 1) Attach metadata to a live bot 2) Tag a recording in progress 3) Correlate a bot with external records",
     {
-      bot_id: z.string(),
-      extra: z.record(z.unknown()).describe("Custom metadata to merge with the bot's existing extra data")
+      title: "Update Bot Config",
+      description: "Update a running bot's extra metadata (shallow-merged with existing data). Use this when you want to: 1) Attach metadata to a live bot 2) Tag a recording in progress 3) Correlate a bot with external records",
+      inputSchema: {
+        bot_id: z.string(),
+        extra: z.record(z.unknown()).describe("Custom metadata to merge with the bot's existing extra data")
+      },
+      annotations: { destructiveHint: false }
     },
     async (args) => {
       console.log("Attempting to update bot config", { bot_id: args.bot_id })
@@ -430,12 +474,16 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Send Chat Message
-  server.tool(
+  server.registerTool(
     "sendChatMessage",
-    "Send a chat message into the meeting via the bot. Use this when you want to: 1) Post a message to participants 2) Share a link or instruction 3) Acknowledge something in the meeting chat",
     {
-      bot_id: z.string(),
-      message: chatMessageSchema.describe("The chat message text to send in the meeting (1-500 chars)")
+      title: "Send Chat Message",
+      description: "Send a chat message into the meeting via the bot. Use this when you want to: 1) Post a message to participants 2) Share a link or instruction 3) Acknowledge something in the meeting chat",
+      inputSchema: {
+        bot_id: z.string(),
+        message: chatMessageSchema.describe("The chat message text to send in the meeting (1-500 chars)")
+      },
+      annotations: { destructiveHint: false }
     },
     async (args) => {
       console.log("Attempting to send chat message", { bot_id: args.bot_id })
@@ -454,12 +502,16 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Pause Bot Recording
-  server.tool(
+  server.registerTool(
     "pauseBotRecording",
-    "Pause an in-progress recording for a live bot, optionally posting a chat message to participants. Use this when you want to: 1) Temporarily stop recording sensitive discussion 2) Pause during a break 3) Control recording without removing the bot",
     {
-      bot_id: z.string(),
-      chat_message: chatMessageSchema.optional().describe("Optional message to post to participants when pausing")
+      title: "Pause Bot Recording",
+      description: "Pause an in-progress recording for a live bot, optionally posting a chat message to participants. Use this when you want to: 1) Temporarily stop recording sensitive discussion 2) Pause during a break 3) Control recording without removing the bot",
+      inputSchema: {
+        bot_id: z.string(),
+        chat_message: chatMessageSchema.optional().describe("Optional message to post to participants when pausing")
+      },
+      annotations: { destructiveHint: false }
     },
     async (args) => {
       console.log("Attempting to pause bot recording", { bot_id: args.bot_id })
@@ -479,12 +531,16 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Resume Bot Recording
-  server.tool(
+  server.registerTool(
     "resumeBotRecording",
-    "Resume a paused recording for a live bot, optionally posting a chat message to participants. Use this when you want to: 1) Continue recording after a pause 2) Resume after a break 3) Re-enable capture without re-joining",
     {
-      bot_id: z.string(),
-      chat_message: chatMessageSchema.optional().describe("Optional message to post to participants when resuming")
+      title: "Resume Bot Recording",
+      description: "Resume a paused recording for a live bot, optionally posting a chat message to participants. Use this when you want to: 1) Continue recording after a pause 2) Resume after a break 3) Re-enable capture without re-joining",
+      inputSchema: {
+        bot_id: z.string(),
+        chat_message: chatMessageSchema.optional().describe("Optional message to post to participants when resuming")
+      },
+      annotations: { destructiveHint: false }
     },
     async (args) => {
       console.log("Attempting to resume bot recording", { bot_id: args.bot_id })
@@ -506,12 +562,16 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   // --- Scheduled Bots ---
 
   // Create Scheduled Bot
-  server.tool(
+  server.registerTool(
     "createScheduledBot",
-    "Schedule a bot to join a meeting at a future time. Use this when you want to: 1) Pre-schedule meeting recordings 2) Set up bots for upcoming meetings 3) Automate meeting attendance",
     {
-      ...botConfigShape,
-      join_at: z.string().describe("ISO8601 timestamp for when the bot should join the meeting")
+      title: "Create Scheduled Bot",
+      description: "Schedule a bot to join a meeting at a future time. Use this when you want to: 1) Pre-schedule meeting recordings 2) Set up bots for upcoming meetings 3) Automate meeting attendance",
+      inputSchema: {
+        ...botConfigShape,
+        join_at: z.string().describe("ISO8601 timestamp for when the bot should join the meeting")
+      },
+      annotations: { destructiveHint: false }
     },
     async (args) => {
       console.log("Attempting to create scheduled bot", redactArgs(args))
@@ -530,10 +590,14 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // List Scheduled Bots
-  server.tool(
+  server.registerTool(
     "listScheduledBots",
-    "List all scheduled bots. Use this when you want to: 1) View upcoming scheduled recordings 2) Check scheduled bot status 3) Monitor planned bot activity",
-    V2Zod.listScheduledBotsQueryParams.shape,
+    {
+      title: "List Scheduled Bots",
+      description: "List all scheduled bots. Use this when you want to: 1) View upcoming scheduled recordings 2) Check scheduled bot status 3) Monitor planned bot activity",
+      inputSchema: V2Zod.listScheduledBotsQueryParams.shape,
+      annotations: { readOnlyHint: true }
+    },
     async (args) => {
       console.log("Attempting to list scheduled bots", redactArgs(args))
       const result = await baasClient.listScheduledBots(args)
@@ -551,10 +615,14 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Get Scheduled Bot
-  server.tool(
+  server.registerTool(
     "getScheduledBot",
-    "Get details about a specific scheduled bot. Use this when you want to: 1) Check scheduled bot configuration 2) Verify scheduling details 3) Review bot settings before it joins",
-    { bot_id: z.string() },
+    {
+      title: "Get Scheduled Bot",
+      description: "Get details about a specific scheduled bot. Use this when you want to: 1) Check scheduled bot configuration 2) Verify scheduling details 3) Review bot settings before it joins",
+      inputSchema: { bot_id: z.string() },
+      annotations: { readOnlyHint: true }
+    },
     async (args) => {
       console.log("Attempting to get scheduled bot", redactArgs(args))
       const result = await baasClient.getScheduledBot({ bot_id: args.bot_id })
@@ -572,10 +640,14 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Delete Scheduled Bot
-  server.tool(
+  server.registerTool(
     "deleteScheduledBot",
-    "Delete a scheduled bot. Use this when you want to: 1) Cancel a scheduled recording 2) Remove a planned bot 3) Stop a bot from joining a future meeting",
-    { bot_id: z.string() },
+    {
+      title: "Delete Scheduled Bot",
+      description: "Delete a scheduled bot. Use this when you want to: 1) Cancel a scheduled recording 2) Remove a planned bot 3) Stop a bot from joining a future meeting",
+      inputSchema: { bot_id: z.string() },
+      annotations: { destructiveHint: true, idempotentHint: true }
+    },
     async (args) => {
       console.log("Attempting to delete scheduled bot", redactArgs(args))
       const result = await baasClient.deleteScheduledBot({ bot_id: args.bot_id })
@@ -593,14 +665,18 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Batch Create Scheduled Bots
-  server.tool(
+  server.registerTool(
     "batchCreateScheduledBots",
-    "Schedule multiple bots in a single request. Use this when you want to: 1) Pre-schedule recordings for many meetings at once 2) Bulk-automate future attendance 3) Reduce round-trips when scheduling",
     {
-      bots: z.array(z.object({
-        ...botConfigShape,
-        join_at: z.string().describe("ISO8601 timestamp for when the bot should join the meeting")
-      })).min(1).describe("Array of scheduled bot configurations")
+      title: "Batch Create Scheduled Bots",
+      description: "Schedule multiple bots in a single request. Use this when you want to: 1) Pre-schedule recordings for many meetings at once 2) Bulk-automate future attendance 3) Reduce round-trips when scheduling",
+      inputSchema: {
+        bots: z.array(z.object({
+          ...botConfigShape,
+          join_at: z.string().describe("ISO8601 timestamp for when the bot should join the meeting")
+        })).min(1).describe("Array of scheduled bot configurations")
+      },
+      annotations: { destructiveHint: false }
     },
     async (args) => {
       console.log("Attempting to batch create scheduled bots", { count: args.bots.length })
@@ -619,13 +695,17 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Update Scheduled Bot
-  server.tool(
+  server.registerTool(
     "updateScheduledBot",
-    "Update the configuration of a scheduled bot before it joins. Use this when you want to: 1) Change a scheduled bot's settings 2) Update the meeting URL 3) Adjust recording or timeout options",
     {
-      bot_id: z.string(),
-      ...botUpdateShape,
-      join_at: z.string().optional().describe("ISO8601 timestamp for when the bot should join the meeting")
+      title: "Update Scheduled Bot",
+      description: "Update the configuration of a scheduled bot before it joins. Use this when you want to: 1) Change a scheduled bot's settings 2) Update the meeting URL 3) Adjust recording or timeout options",
+      inputSchema: {
+        bot_id: z.string(),
+        ...botUpdateShape,
+        join_at: z.string().optional().describe("ISO8601 timestamp for when the bot should join the meeting")
+      },
+      annotations: { destructiveHint: false }
     },
     async (args) => {
       const { bot_id, ...body } = args
@@ -647,10 +727,14 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   // --- Calendar Connections ---
 
   // Create Calendar Connection (equivalent to v1 createCalendar)
-  server.tool(
+  server.registerTool(
     "createCalendarConnection",
-    "Create a new calendar connection. Use this when you want to: 1) Set up automatic meeting recordings 2) Configure calendar-based bot scheduling 3) Enable recurring meeting coverage",
-    V2ZodCalendars.createCalendarConnectionBody.shape,
+    {
+      title: "Create Calendar Connection",
+      description: "Create a new calendar connection. Use this when you want to: 1) Set up automatic meeting recordings 2) Configure calendar-based bot scheduling 3) Enable recurring meeting coverage",
+      inputSchema: V2ZodCalendars.createCalendarConnectionBody.shape,
+      annotations: { destructiveHint: false }
+    },
     async (args) => {
       console.log("Attempting to create calendar connection", redactArgs(args))
       const result = await baasClient.createCalendarConnection(args)
@@ -668,10 +752,14 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // List Calendars
-  server.tool(
+  server.registerTool(
     "listCalendars",
-    "List all calendar connections. Use this when you want to: 1) View configured calendars 2) Check calendar status 3) Manage calendar integrations",
-    V2ZodCalendars.listCalendarsQueryParams.shape,
+    {
+      title: "List Calendars",
+      description: "List all calendar connections. Use this when you want to: 1) View configured calendars 2) Check calendar status 3) Manage calendar integrations",
+      inputSchema: V2ZodCalendars.listCalendarsQueryParams.shape,
+      annotations: { readOnlyHint: true }
+    },
     async (args) => {
       console.log("Attempting to list calendars", redactArgs(args))
       const result = await baasClient.listCalendars(args)
@@ -689,10 +777,14 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Get Calendar Details (equivalent to v1 getCalendar)
-  server.tool(
+  server.registerTool(
     "getCalendarDetails",
-    "Get details about a specific calendar connection. Use this when you want to: 1) View calendar configuration 2) Check calendar status 3) Verify calendar settings",
-    { calendar_id: z.string() },
+    {
+      title: "Get Calendar Details",
+      description: "Get details about a specific calendar connection. Use this when you want to: 1) View calendar configuration 2) Check calendar status 3) Verify calendar settings",
+      inputSchema: { calendar_id: z.string() },
+      annotations: { readOnlyHint: true }
+    },
     async (args) => {
       console.log("Attempting to get calendar details", redactArgs(args))
       const result = await baasClient.getCalendarDetails({ calendar_id: args.calendar_id })
@@ -710,15 +802,19 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Update Calendar Connection (equivalent to v1 updateCalendar)
-  server.tool(
+  server.registerTool(
     "updateCalendarConnection",
-    "Update a calendar connection configuration. Use this when you want to: 1) Modify calendar settings 2) Update OAuth credentials 3) Change calendar configuration",
     {
-      calendar_id: z.string(),
-      oauth_client_id: z.string(),
-      oauth_client_secret: z.string(),
-      oauth_refresh_token: z.string(),
-      oauth_tenant_id: z.string().optional()
+      title: "Update Calendar Connection",
+      description: "Update a calendar connection configuration. Use this when you want to: 1) Modify calendar settings 2) Update OAuth credentials 3) Change calendar configuration",
+      inputSchema: {
+        calendar_id: z.string(),
+        oauth_client_id: z.string(),
+        oauth_client_secret: z.string(),
+        oauth_refresh_token: z.string(),
+        oauth_tenant_id: z.string().optional()
+      },
+      annotations: { destructiveHint: false }
     },
     async (args) => {
       const { calendar_id, ...body } = args
@@ -738,10 +834,14 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Delete Calendar Connection (equivalent to v1 deleteCalendar)
-  server.tool(
+  server.registerTool(
     "deleteCalendarConnection",
-    "Delete a calendar connection. Use this when you want to: 1) Remove a calendar connection 2) Stop automatic recordings 3) Clean up calendar data",
-    { calendar_id: z.string() },
+    {
+      title: "Delete Calendar Connection",
+      description: "Delete a calendar connection. Use this when you want to: 1) Remove a calendar connection 2) Stop automatic recordings 3) Clean up calendar data",
+      inputSchema: { calendar_id: z.string() },
+      annotations: { destructiveHint: true, idempotentHint: true }
+    },
     async (args) => {
       console.log("Attempting to delete calendar connection", redactArgs(args))
       const result = await baasClient.deleteCalendarConnection({ calendar_id: args.calendar_id })
@@ -759,10 +859,14 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Sync Calendar (equivalent to v1 resyncAllCalendars but per-calendar)
-  server.tool(
+  server.registerTool(
     "syncCalendar",
-    "Synchronize a specific calendar to fetch the latest events. Use this when you want to: 1) Force a calendar sync 2) Update event data 3) Refresh calendar information",
-    { calendar_id: z.string() },
+    {
+      title: "Sync Calendar",
+      description: "Synchronize a specific calendar to fetch the latest events. Use this when you want to: 1) Force a calendar sync 2) Update event data 3) Refresh calendar information",
+      inputSchema: { calendar_id: z.string() },
+      annotations: { destructiveHint: false }
+    },
     async (args) => {
       console.log("Attempting to sync calendar", redactArgs(args))
       const result = await baasClient.syncCalendar({ calendar_id: args.calendar_id })
@@ -780,10 +884,14 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Resubscribe Calendar
-  server.tool(
+  server.registerTool(
     "resubscribeCalendar",
-    "Resubscribe a calendar's push notifications. Use this when you want to: 1) Restore event updates after a subscription lapses 2) Recover from missed calendar webhooks 3) Refresh the provider subscription",
-    { calendar_id: z.string() },
+    {
+      title: "Resubscribe Calendar",
+      description: "Resubscribe a calendar's push notifications. Use this when you want to: 1) Restore event updates after a subscription lapses 2) Recover from missed calendar webhooks 3) Refresh the provider subscription",
+      inputSchema: { calendar_id: z.string() },
+      annotations: { destructiveHint: false }
+    },
     async (args) => {
       console.log("Attempting to resubscribe calendar", redactArgs(args))
       const result = await baasClient.resubscribeCalendar({ calendar_id: args.calendar_id })
@@ -801,15 +909,19 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // List Raw Calendars
-  server.tool(
+  server.registerTool(
     "listRawCalendars",
-    "List the raw calendars available from an OAuth provider before creating a connection. Use this when you want to: 1) Discover which calendars an account exposes 2) Find a calendar's id to connect 3) Verify OAuth credentials work",
     {
-      calendar_platform: z.enum(["google", "microsoft"]).describe("The calendar platform: 'google' or 'microsoft'"),
-      oauth_client_id: z.string(),
-      oauth_client_secret: z.string(),
-      oauth_refresh_token: z.string(),
-      oauth_tenant_id: z.string().optional()
+      title: "List Raw Calendars",
+      description: "List the raw calendars available from an OAuth provider before creating a connection. Use this when you want to: 1) Discover which calendars an account exposes 2) Find a calendar's id to connect 3) Verify OAuth credentials work",
+      inputSchema: {
+        calendar_platform: z.enum(["google", "microsoft"]).describe("The calendar platform: 'google' or 'microsoft'"),
+        oauth_client_id: z.string(),
+        oauth_client_secret: z.string(),
+        oauth_refresh_token: z.string(),
+        oauth_tenant_id: z.string().optional()
+      },
+      annotations: { readOnlyHint: true }
     },
     async (args) => {
       console.log("Attempting to list raw calendars", redactArgs(args))
@@ -830,16 +942,20 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   // --- Calendar Events ---
 
   // List Events
-  server.tool(
+  server.registerTool(
     "listEvents",
-    "List calendar events. Use this when you want to: 1) View upcoming meetings 2) Check scheduled events 3) Browse calendar entries",
     {
-      calendar_id: z.string(),
-      limit: z.number().optional(),
-      cursor: z.string().optional(),
-      show_cancelled: z.boolean().optional(),
-      start_date: z.string().optional(),
-      end_date: z.string().optional()
+      title: "List Events",
+      description: "List calendar events. Use this when you want to: 1) View upcoming meetings 2) Check scheduled events 3) Browse calendar entries",
+      inputSchema: {
+        calendar_id: z.string(),
+        limit: z.number().optional(),
+        cursor: z.string().optional(),
+        show_cancelled: z.boolean().optional(),
+        start_date: z.string().optional(),
+        end_date: z.string().optional()
+      },
+      annotations: { readOnlyHint: true }
     },
     async (args) => {
       const { calendar_id, ...query } = args
@@ -859,10 +975,14 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Get Event Details
-  server.tool(
+  server.registerTool(
     "getEventDetails",
-    "Get detailed information about a specific calendar event. Use this when you want to: 1) View event details 2) Check attendees 3) See event configuration",
-    { calendar_id: z.string(), event_id: z.string() },
+    {
+      title: "Get Event Details",
+      description: "Get detailed information about a specific calendar event. Use this when you want to: 1) View event details 2) Check attendees 3) See event configuration",
+      inputSchema: { calendar_id: z.string(), event_id: z.string() },
+      annotations: { readOnlyHint: true }
+    },
     async (args) => {
       console.log("Attempting to get event details", redactArgs(args))
       const result = await baasClient.getEventDetails({
@@ -883,15 +1003,19 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // List Event Series
-  server.tool(
+  server.registerTool(
     "listEventSeries",
-    "List recurring event series for a calendar. Use this when you want to: 1) Find recurring meetings 2) Schedule a bot across all occurrences of a series 3) Browse repeating calendar entries",
     {
-      calendar_id: z.string(),
-      limit: z.number().optional(),
-      cursor: z.string().optional(),
-      event_type: z.string().optional(),
-      show_cancelled: z.boolean().optional()
+      title: "List Event Series",
+      description: "List recurring event series for a calendar. Use this when you want to: 1) Find recurring meetings 2) Schedule a bot across all occurrences of a series 3) Browse repeating calendar entries",
+      inputSchema: {
+        calendar_id: z.string(),
+        limit: z.number().optional(),
+        cursor: z.string().optional(),
+        event_type: z.string().optional(),
+        show_cancelled: z.boolean().optional()
+      },
+      annotations: { readOnlyHint: true }
     },
     async (args) => {
       const { calendar_id, ...query } = args
@@ -913,15 +1037,19 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   // --- Calendar Bots ---
 
   // Create Calendar Bot (equivalent to v1 scheduleRecordEvent)
-  server.tool(
+  server.registerTool(
     "createCalendarBot",
-    "Schedule a bot to record a calendar event. Use this when you want to: 1) Set up automatic recording for a calendar event 2) Schedule future transcriptions 3) Plan meeting recordings based on calendar",
     {
-      calendar_id: z.string(),
-      series_id: z.string().describe("UUID of the event series to schedule bots for"),
-      all_occurrences: z.boolean().describe("Whether to schedule bots for all occurrences of the event series"),
-      event_id: z.string().optional().describe("UUID of a specific event instance (required when all_occurrences is false)"),
-      ...botConfigShape
+      title: "Create Calendar Bot",
+      description: "Schedule a bot to record a calendar event. Use this when you want to: 1) Set up automatic recording for a calendar event 2) Schedule future transcriptions 3) Plan meeting recordings based on calendar",
+      inputSchema: {
+        calendar_id: z.string(),
+        series_id: z.string().describe("UUID of the event series to schedule bots for"),
+        all_occurrences: z.boolean().describe("Whether to schedule bots for all occurrences of the event series"),
+        event_id: z.string().optional().describe("UUID of a specific event instance (required when all_occurrences is false)"),
+        ...botConfigShape
+      },
+      annotations: { destructiveHint: false }
     },
     async (args) => {
       if (!args.all_occurrences && !args.event_id) {
@@ -947,12 +1075,16 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Delete Calendar Bot (equivalent to v1 unscheduleRecordEvent)
-  server.tool(
+  server.registerTool(
     "deleteCalendarBot",
-    "Cancel a scheduled calendar bot recording. Use this when you want to: 1) Cancel automatic recording 2) Stop planned transcription 3) Remove scheduled bot activity for an event",
     {
-      calendar_id: z.string(),
-      event_id: z.string()
+      title: "Delete Calendar Bot",
+      description: "Cancel a scheduled calendar bot recording. Use this when you want to: 1) Cancel automatic recording 2) Stop planned transcription 3) Remove scheduled bot activity for an event",
+      inputSchema: {
+        calendar_id: z.string(),
+        event_id: z.string()
+      },
+      annotations: { destructiveHint: true, idempotentHint: true }
     },
     async (args) => {
       console.log("Attempting to delete calendar bot", redactArgs(args))
@@ -974,15 +1106,19 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Update Calendar Bot
-  server.tool(
+  server.registerTool(
     "updateCalendarBot",
-    "Update the configuration of a bot scheduled for a calendar event. Use this when you want to: 1) Change recording settings for a scheduled calendar bot 2) Adjust bot options before the event 3) Modify a calendar-driven recording",
     {
-      calendar_id: z.string(),
-      event_id: z.string().describe("UUID of the event instance whose bot configuration is being updated"),
-      series_id: z.string().describe("UUID of the event series the bot is scheduled for"),
-      all_occurrences: z.boolean().describe("Whether the update applies to all occurrences of the event series"),
-      ...botUpdateShape
+      title: "Update Calendar Bot",
+      description: "Update the configuration of a bot scheduled for a calendar event. Use this when you want to: 1) Change recording settings for a scheduled calendar bot 2) Adjust bot options before the event 3) Modify a calendar-driven recording",
+      inputSchema: {
+        calendar_id: z.string(),
+        event_id: z.string().describe("UUID of the event instance whose bot configuration is being updated"),
+        series_id: z.string().describe("UUID of the event series the bot is scheduled for"),
+        all_occurrences: z.boolean().describe("Whether the update applies to all occurrences of the event series"),
+        ...botUpdateShape
+      },
+      annotations: { destructiveHint: false }
     },
     async (args) => {
       const { calendar_id, event_id, ...body } = args
@@ -1004,10 +1140,14 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   // --- Zoom Credentials ---
 
   // Create Zoom Credential
-  server.tool(
+  server.registerTool(
     "createZoomCredential",
-    "Store Zoom OAuth credentials for joining Zoom meetings with the Meeting SDK. Use this when you want to: 1) Enable Zoom SDK-based recording 2) Register a Zoom app's client credentials 3) Set up Zoom authentication",
-    zoomCredentialShape,
+    {
+      title: "Create Zoom Credential",
+      description: "Store Zoom OAuth credentials for joining Zoom meetings with the Meeting SDK. Use this when you want to: 1) Enable Zoom SDK-based recording 2) Register a Zoom app's client credentials 3) Set up Zoom authentication",
+      inputSchema: zoomCredentialShape,
+      annotations: { destructiveHint: false }
+    },
     async (args) => {
       console.log("Attempting to create zoom credential", redactArgs(args))
       const result = await baasClient.createZoomCredential(args)
@@ -1025,17 +1165,21 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // List Zoom Credentials
-  server.tool(
+  server.registerTool(
     "listZoomCredentials",
-    "List stored Zoom credentials. Use this when you want to: 1) View configured Zoom apps 2) Find a credential id 3) Audit Zoom integration settings",
     {
-      name: z.string().optional(),
-      zoom_email: z.string().optional(),
-      zoom_display_name: z.string().optional(),
-      zoom_user_id: z.string().optional(),
-      credential_type: z.string().optional(),
-      state: z.string().optional(),
-      extra: z.string().optional()
+      title: "List Zoom Credentials",
+      description: "List stored Zoom credentials. Use this when you want to: 1) View configured Zoom apps 2) Find a credential id 3) Audit Zoom integration settings",
+      inputSchema: {
+        name: z.string().optional(),
+        zoom_email: z.string().optional(),
+        zoom_display_name: z.string().optional(),
+        zoom_user_id: z.string().optional(),
+        credential_type: z.string().optional(),
+        state: z.string().optional(),
+        extra: z.string().optional()
+      },
+      annotations: { readOnlyHint: true }
     },
     async (args) => {
       console.log("Attempting to list zoom credentials", redactArgs(args))
@@ -1054,10 +1198,14 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Get Zoom Credential
-  server.tool(
+  server.registerTool(
     "getZoomCredential",
-    "Get details about a specific Zoom credential. Use this when you want to: 1) Inspect a stored Zoom credential 2) Verify its configuration 3) Check the linked Zoom account",
-    { id: z.string() },
+    {
+      title: "Get Zoom Credential",
+      description: "Get details about a specific Zoom credential. Use this when you want to: 1) Inspect a stored Zoom credential 2) Verify its configuration 3) Check the linked Zoom account",
+      inputSchema: { id: z.string() },
+      annotations: { readOnlyHint: true }
+    },
     async (args) => {
       console.log("Attempting to get zoom credential", redactArgs(args))
       const result = await baasClient.getZoomCredential({ id: args.id })
@@ -1075,17 +1223,21 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Update Zoom Credential
-  server.tool(
+  server.registerTool(
     "updateZoomCredential",
-    "Update a stored Zoom credential. Use this when you want to: 1) Rotate Zoom client secrets 2) Rename a credential 3) Re-authorize with a new authorization code",
     {
-      id: z.string(),
-      name: z.string().min(1).max(100).optional(),
-      client_id: z.string().optional(),
-      client_secret: z.string().optional(),
-      authorization_code: z.string().optional(),
-      redirect_uri: z.string().optional(),
-      extra: z.record(z.unknown()).optional()
+      title: "Update Zoom Credential",
+      description: "Update a stored Zoom credential. Use this when you want to: 1) Rotate Zoom client secrets 2) Rename a credential 3) Re-authorize with a new authorization code",
+      inputSchema: {
+        id: z.string(),
+        name: z.string().min(1).max(100).optional(),
+        client_id: z.string().optional(),
+        client_secret: z.string().optional(),
+        authorization_code: z.string().optional(),
+        redirect_uri: z.string().optional(),
+        extra: z.record(z.unknown()).optional()
+      },
+      annotations: { destructiveHint: false }
     },
     async (args) => {
       const { id, ...body } = args
@@ -1105,10 +1257,14 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   )
 
   // Delete Zoom Credential
-  server.tool(
+  server.registerTool(
     "deleteZoomCredential",
-    "Delete a stored Zoom credential. Use this when you want to: 1) Remove an unused Zoom credential 2) Revoke a compromised credential 3) Clean up Zoom integration settings",
-    { id: z.string() },
+    {
+      title: "Delete Zoom Credential",
+      description: "Delete a stored Zoom credential. Use this when you want to: 1) Remove an unused Zoom credential 2) Revoke a compromised credential 3) Clean up Zoom integration settings",
+      inputSchema: { id: z.string() },
+      annotations: { destructiveHint: true, idempotentHint: true }
+    },
     async (args) => {
       console.log("Attempting to delete zoom credential", redactArgs(args))
       const result = await baasClient.deleteZoomCredential({ id: args.id })
@@ -1128,12 +1284,16 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
   // --- AI Agent Tools ---
 
   // Get Transcript
-  server.tool(
+  server.registerTool(
     "getTranscript",
-    "Get a meeting transcript as a readable dialog or full JSON with metadata. Use this when you want to: 1) Read what was said in a meeting 2) Get a conversation summary 3) Access raw transcription data",
     {
-      bot_id: z.string(),
-      format: z.enum(["dialog", "full"]).default("dialog").describe("'dialog' returns a readable merged conversation, 'full' returns the raw transcription JSON")
+      title: "Get Transcript",
+      description: "Get a meeting transcript as a readable dialog or full JSON with metadata. Use this when you want to: 1) Read what was said in a meeting 2) Get a conversation summary 3) Access raw transcription data",
+      inputSchema: {
+        bot_id: z.string(),
+        format: z.enum(["dialog", "full"]).default("dialog").describe("'dialog' returns a readable merged conversation, 'full' returns the raw transcription JSON")
+      },
+      annotations: { readOnlyHint: true }
     },
     async (args) => {
       console.log("Attempting to get transcript", { bot_id: args.bot_id, format: args.format })
@@ -1221,16 +1381,6 @@ export function registerV2Tools(server: McpServer, apiKey: string, baseUrl?: str
       }
     }
   )
-
-  // Add echo tool for testing
-  server.tool("echo", { message: z.string() }, async ({ message }: { message: string }) => ({
-    content: [
-      {
-        type: "text" as const,
-        text: `Tool echo: ${message}`
-      }
-    ]
-  }))
 
   return server
 }

--- a/docs/MARKETPLACE-PLAN.md
+++ b/docs/MARKETPLACE-PLAN.md
@@ -1,0 +1,134 @@
+# Meeting BaaS — ChatGPT Apps + Claude Marketplace Plan
+
+Goal: one canonical hosted MCP server (`https://mcp.meetingbaas.com/mcp`) that ships as:
+
+1. **ChatGPT App** (Apps SDK directory) — Plus/Team/Enterprise reach
+2. **Claude Connector** (claude.ai connectors directory) — Pro/Max/Team/Enterprise one-click install
+3. **Claude Code plugin** (plugin marketplace) — dev audience
+4. **Codex CLI / any MCP client** — same URL, plain MCP, no store needed
+
+This repo (`mcp-on-vercel`) is the canonical server. It already has Streamable HTTP
+transport, v1/v2 tools built on `@meeting-baas/sdk`, and session lifecycle management.
+What's missing for the directories: **OAuth 2.1**, **tool annotations**, **well-known
+metadata endpoints**, and (ChatGPT only) an optional **embedded UI component**.
+
+---
+
+## Phase 0 — Consolidation
+
+| Repo | Decision |
+|------|----------|
+| `mcp-on-vercel` | **Canonical.** All marketplace work lands here. |
+| `meeting-mcp` | Archive with a README pointer to the hosted URL. |
+| `speaking-bots-mcp` | Keep separate for now (speaking personas need the Pipecat stack); fold in later as an optional tool group once the core listing is live. |
+| `mcp-on-vercel-documentation` | Unchanged (docs/context server, not user-facing). |
+
+Server-identity cleanup in this repo:
+
+- Rename `McpServer` name from `"mcp-typescript server on vercel"` → `"Meeting BaaS"`, bump version.
+- Default `x-api-version` to **v2** when the client is OAuth-authenticated (directory users
+  should never see the v1/v2 split); keep header override for existing integrations.
+- Remove or dev-gate the `echo` tool (directory reviewers flag junk tools).
+- Upgrade `@modelcontextprotocol/sdk` (currently `^1.10.2`) to latest — needed for
+  `registerTool` + annotations + auth helper types.
+
+## Phase 1 — OAuth 2.1 layer (hard blocker for both stores)
+
+Both directories require real user OAuth; the current API-key-header model stays as a
+side door but can't be the listed auth.
+
+Per the MCP auth spec we need:
+
+- **Authorization Code + PKCE** (OAuth 2.1)
+- **RFC 9728** Protected Resource Metadata at `/.well-known/oauth-protected-resource`
+- **RFC 8414** Authorization Server Metadata at `/.well-known/oauth-authorization-server`
+- **RFC 7591** Dynamic Client Registration (`/register`) — Claude requires DCR;
+  ChatGPT supports DCR or a manually configured client
+- `401` responses carrying `WWW-Authenticate` with the resource-metadata URL so clients
+  can discover the flow
+
+### Architecture: embedded AS backed by Meeting BaaS accounts
+
+Rather than deploying a separate authorization server, add AS routes to this deployment:
+
+```
+GET  /.well-known/oauth-protected-resource   → static JSON (resource + AS URL)
+GET  /.well-known/oauth-authorization-server → static JSON (endpoints, PKCE S256, scopes)
+POST /register                               → DCR: store client in Redis, return client_id
+GET  /authorize                              → redirect to meetingbaas.com login/consent;
+                                               callback issues auth code (Redis, 60s TTL)
+POST /token                                  → PKCE verify → issue opaque access token
+                                               (Redis: token → { userId, baasApiKey, scopes })
+                                               + refresh token rotation
+```
+
+- **Token ↔ API key mapping**: at consent time, resolve (or mint) the user's Meeting BaaS
+  API key server-side and store it against the token. The MCP handler then validates the
+  Bearer token, looks up the BaaS key, and passes it to `registerTools` exactly as the
+  header path does today — zero changes to the tools layer.
+- **Storage**: Redis (`REDIS_URL` already in `.env.example`) for clients, codes, tokens.
+  Opaque tokens (not JWTs) keep revocation trivial and nothing sensitive client-side.
+- **Login/consent UI**: smallest viable = a consent page on the existing meetingbaas.com
+  dashboard (user already authenticated there) that POSTs approval back to `/authorize`
+  callback. Needs one endpoint on the dashboard side to confirm identity + hand back the
+  API key — coordinate with the main app.
+- **Dual auth in `mcp-api-handler.ts`**: `Authorization: Bearer <oauth-token>` (Redis
+  lookup) OR legacy `x-meeting-baas-api-key` / raw key headers. Reject with 401 +
+  `WWW-Authenticate` only when neither is present.
+
+### Scopes (keep coarse for v1)
+
+- `bots:read`, `bots:write`, `calendars:read`, `calendars:write`, `data:delete`
+
+## Phase 2 — Tool annotations + review hygiene
+
+Migrate `server.tool(...)` calls (`api/tools-v1.ts`, `api/tools-v2.ts`) to
+`registerTool` with annotations — both stores check these:
+
+| Annotation | Tools |
+|------------|-------|
+| `readOnlyHint: true` | getMeetingData, listBots, getBotDetails, getBotStatus, getTranscript, listCalendars, listEvents, getCalendarDetails, getEventDetails, listScheduledBots, getScheduledBot, botsWithMetadata |
+| `destructiveHint: true` | deleteData, deleteBotData, deleteCalendar(Connection), deleteScheduledBot, deleteCalendarBot, leaveMeeting, leaveBot, unscheduleRecordEvent |
+| `openWorldHint: true` | joinMeeting, createBot (bot enters an external meeting) |
+
+Also: tighten tool descriptions (reviewers read them), ensure errors never leak keys,
+confirm no request bodies/headers are logged (handler currently logs env + baseUrl only — keep it that way).
+
+## Phase 3 — ChatGPT Apps specifics
+
+- **Identity verification** in the OpenAI Platform dashboard (org-level, do early — takes days).
+- **Demo credentials** for reviewers: seeded Meeting BaaS test account + a recorded test meeting.
+- **UI component (differentiator, optional for v1)**: Apps SDK component rendered in chat —
+  bot status card / meeting summary card. MCP resource with `_meta.openai/outputTemplate`
+  on `createBot` / `getBotDetails` results. Ship listing first, component in v1.1.
+- Submit via the Apps SDK developer portal; meanwhile test end-to-end in ChatGPT
+  **Developer Mode** against the prod URL.
+
+## Phase 4 — Claude specifics
+
+- **Connectors directory**: submit the URL via claude.ai settings portal. The two
+  known instant-rejects: missing public privacy policy, missing/wrong tool annotations —
+  both covered by Phases 1–2.
+- **Claude Code plugin**: add `.claude-plugin/` (plugin manifest + `mcpServers` entry
+  pointing at the hosted URL) in a `meeting-baas-plugins` repo; PR to
+  `claude-plugins-official`.
+
+## Phase 5 — Submission checklist (both)
+
+- [ ] Public privacy policy URL (stable, on meetingbaas.com)
+- [ ] Support contact + terms
+- [ ] OAuth flow works from a cold client (test with MCP Inspector + Claude + ChatGPT dev mode)
+- [ ] Rate limiting on `/token` + `/register` (Redis counters)
+- [ ] Latency: tool calls < a few seconds; long joins return immediately with bot id
+- [ ] Annotations verified against actual behavior
+- [ ] Reviewer test credentials documented
+
+## Suggested implementation order on this branch
+
+1. SDK upgrade + server rename + v2 default (small, unblocks everything)
+2. Annotations migration (mechanical, big surface — `tools-v2.ts` is 48K)
+3. Well-known endpoints + DCR + token endpoint + Redis store
+4. Consent handshake with meetingbaas.com dashboard (cross-repo, longest pole — start coordination now)
+5. Dual-auth in `mcp-api-handler.ts` + 401/WWW-Authenticate
+6. E2E test with MCP Inspector, Claude, ChatGPT dev mode
+7. Submissions (OpenAI identity verification can run in parallel from day 1)

--- a/flake.nix
+++ b/flake.nix
@@ -23,8 +23,8 @@
             nativeBuildInputs = [ pkgs.nodejs_20 pkgs.pnpm_8 pkgs.pnpmConfigHook pkgs.makeWrapper ];
             pnpmDeps = (pkgs.fetchPnpmDeps.override { pnpm = pkgs.pnpm_8; }) {
               inherit (finalAttrs) pname version src;
-              fetcherVersion = 2;
-              hash = "sha256-TyYTp7GHuJcMhvLhm8B40BkjgLg5U9Xd6vHsT2Ij5k0=";
+              fetcherVersion = 3;
+              hash = "sha256-YMWvj0a0cUO7I8oEi6vW4+jGq9FzQ9ntJi5BLfqo2GE=";
             };
             env = { CI = "true"; };
             buildPhase = ''

--- a/lib/mcp-api-handler.ts
+++ b/lib/mcp-api-handler.ts
@@ -5,6 +5,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { IncomingMessage, ServerResponse } from "http"
 import type z from "zod"
 import { MCP_URL } from "./constants"
+import { buildWwwAuthenticate, handleOAuthRoute, isOAuthAccessToken, resolveAccessToken } from "./oauth"
 import { getApiUrl } from "./utils"
 
 interface ServerOptions extends McpServerOptions {
@@ -45,6 +46,11 @@ export function initializeMcpApiHandler(
   return async function mcpApiHandler(req: IncomingMessage, res: ServerResponse) {
     const url = new URL(req.url || "", MCP_URL)
 
+    // OAuth authorization server + metadata endpoints (marketplace clients)
+    if (await handleOAuthRoute(req, res, url)) {
+      return
+    }
+
     if (url.pathname !== "/mcp") {
       res.statusCode = 404
       res.end("Not found")
@@ -83,14 +89,65 @@ export function initializeMcpApiHandler(
     }
     console.log("API version:", apiVersion)
 
-    // Extract API key from headers
-    apiKey =
-      (req.headers["x-meeting-baas-api-key"] as string) ||
-      (req.headers["x-meetingbaas-apikey"] as string) ||
-      (req.headers["x-api-key"] as string) ||
-      (req.headers["authorization"] as string)?.replace(/bearer\s+/i, "") ||
-      (process.env.NODE_ENV === "development" ? process.env.BAAS_API_KEY : null) ||
-      null
+    // Extract credentials: an OAuth access token (marketplace clients) or a raw
+    // API key in legacy headers. Opaque mbt_* tokens resolve to the user's
+    // Meeting BaaS API key via Redis; any other Authorization value is treated
+    // as a raw API key for backward compatibility.
+    const bearer = (req.headers["authorization"] as string)?.replace(/^bearer\s+/i, "") || null
+    if (bearer && isOAuthAccessToken(bearer)) {
+      const record = await resolveAccessToken(bearer)
+      if (!record) {
+        res
+          .writeHead(401, {
+            "Content-Type": "application/json",
+            "WWW-Authenticate": buildWwwAuthenticate("invalid_token")
+          })
+          .end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              error: { code: -32000, message: "Invalid or expired access token." },
+              id: null
+            })
+          )
+        return
+      }
+      apiKey = record.api_key
+      // OAuth clients come from the marketplaces and should always get the v2
+      // tools unless they explicitly pin a version.
+      if (versionValue === undefined) {
+        apiVersion = "v2"
+      }
+    } else {
+      apiKey =
+        (req.headers["x-meeting-baas-api-key"] as string) ||
+        (req.headers["x-meetingbaas-apikey"] as string) ||
+        (req.headers["x-api-key"] as string) ||
+        bearer ||
+        (process.env.NODE_ENV === "development" ? process.env.BAAS_API_KEY : null) ||
+        null
+    }
+
+    // No credentials at all: challenge with the resource metadata URL so OAuth
+    // clients can discover the authorization server (RFC 9728).
+    if (!apiKey && req.method === "POST") {
+      res
+        .writeHead(401, {
+          "Content-Type": "application/json",
+          "WWW-Authenticate": buildWwwAuthenticate()
+        })
+        .end(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            error: {
+              code: -32000,
+              message:
+                "Authentication required. Provide a Meeting BaaS API key header or complete the OAuth flow."
+            },
+            id: null
+          })
+        )
+      return
+    }
 
     // Route to existing session or create a new one
     const sessionId = req.headers["mcp-session-id"] as string | undefined
@@ -115,8 +172,8 @@ export function initializeMcpApiHandler(
 
       const server = new McpServer(
         {
-          name: "mcp-typescript server on vercel",
-          version: "0.1.0"
+          name: "Meeting BaaS",
+          version: "1.0.0"
         },
         serverOptions
       )

--- a/lib/oauth.ts
+++ b/lib/oauth.ts
@@ -1,0 +1,444 @@
+import crypto from "node:crypto"
+import type { IncomingMessage, ServerResponse } from "http"
+import getRawBody from "raw-body"
+import { MCP_URL } from "./constants"
+import { getRedis } from "./redis"
+
+/**
+ * OAuth 2.1 authorization server for the Meeting BaaS MCP server, per the MCP
+ * authorization spec:
+ *
+ *  - RFC 9728 Protected Resource Metadata  (/.well-known/oauth-protected-resource)
+ *  - RFC 8414 Authorization Server Metadata (/.well-known/oauth-authorization-server)
+ *  - RFC 7591 Dynamic Client Registration   (POST /oauth/register)
+ *  - Authorization Code + PKCE (S256 only)  (GET /oauth/authorize, POST /oauth/token)
+ *  - Refresh token rotation
+ *
+ * User authentication is delegated to the Meeting BaaS dashboard: /oauth/authorize
+ * parks the request in Redis and redirects the browser to OAUTH_CONSENT_URL. After
+ * the user logs in and approves, the dashboard backend calls
+ * POST /oauth/consent/complete (authenticated with OAUTH_CONSENT_SECRET) with the
+ * user's Meeting BaaS API key; we mint the authorization code and hand back the
+ * redirect URL. Access tokens are opaque and map to that API key in Redis, so the
+ * MCP tools layer keeps receiving a plain API key and revocation is a key delete.
+ */
+
+const ISSUER = (process.env.OAUTH_ISSUER || MCP_URL).replace(/\/$/, "")
+const CONSENT_URL = process.env.OAUTH_CONSENT_URL || ""
+const CONSENT_SECRET = process.env.OAUTH_CONSENT_SECRET || ""
+
+const AUTH_REQUEST_TTL_S = 10 * 60
+const CODE_TTL_S = 2 * 60
+const ACCESS_TOKEN_TTL_S = Number(process.env.OAUTH_ACCESS_TOKEN_TTL_S) || 60 * 60
+const REFRESH_TOKEN_TTL_S = Number(process.env.OAUTH_REFRESH_TOKEN_TTL_S) || 30 * 24 * 60 * 60
+
+const SCOPES = ["bots:read", "bots:write", "calendars:read", "calendars:write", "data:delete"]
+
+interface OAuthClient {
+  client_id: string
+  client_name?: string
+  redirect_uris: string[]
+  token_endpoint_auth_method: "none"
+  client_id_issued_at: number
+}
+
+interface AuthRequest {
+  client_id: string
+  redirect_uri: string
+  code_challenge: string
+  state?: string
+  scope: string
+}
+
+interface CodeGrant extends AuthRequest {
+  api_key: string
+  user_id: string
+}
+
+interface TokenRecord {
+  api_key: string
+  user_id: string
+  client_id: string
+  scope: string
+}
+
+const randomToken = (prefix: string) => `${prefix}_${crypto.randomBytes(32).toString("hex")}`
+const sha256b64url = (input: string) => crypto.createHash("sha256").update(input).digest("base64url")
+
+function sendJson(res: ServerResponse, status: number, body: unknown, headers: Record<string, string> = {}) {
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Cache-Control": "no-store",
+    "Access-Control-Allow-Origin": "*",
+    ...headers
+  })
+  res.end(JSON.stringify(body))
+}
+
+function oauthError(res: ServerResponse, status: number, error: string, description: string) {
+  sendJson(res, status, { error, error_description: description })
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+  const raw = await getRawBody(req, { limit: "64kb" })
+  return JSON.parse(raw.toString("utf8"))
+}
+
+/** Token endpoint accepts application/x-www-form-urlencoded (spec) or JSON (lenient). */
+async function readFormBody(req: IncomingMessage): Promise<Record<string, string>> {
+  const raw = (await getRawBody(req, { limit: "64kb" })).toString("utf8")
+  if ((req.headers["content-type"] || "").includes("application/json")) {
+    return JSON.parse(raw)
+  }
+  return Object.fromEntries(new URLSearchParams(raw))
+}
+
+function isAllowedRedirectUri(uri: string): boolean {
+  try {
+    const u = new URL(uri)
+    if (u.protocol === "https:") return true
+    // Loopback redirects are allowed for native/CLI clients (OAuth 2.1 §8.4.2)
+    return u.protocol === "http:" && (u.hostname === "localhost" || u.hostname === "127.0.0.1")
+  } catch {
+    return false
+  }
+}
+
+/** Fixed-window per-IP rate limit backed by Redis. Returns true when over limit. */
+async function rateLimited(req: IncomingMessage, bucket: string, limitPerMinute: number): Promise<boolean> {
+  const ip =
+    (req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() ||
+    req.socket.remoteAddress ||
+    "unknown"
+  const key = `oauth:rl:${bucket}:${ip}:${Math.floor(Date.now() / 60_000)}`
+  const redis = getRedis()
+  const count = await redis.incr(key)
+  if (count === 1) await redis.expire(key, 60)
+  return count > limitPerMinute
+}
+
+export function buildWwwAuthenticate(error?: string): string {
+  const parts = [`Bearer resource_metadata="${ISSUER}/.well-known/oauth-protected-resource"`]
+  if (error) parts.push(`error="${error}"`)
+  return parts.join(", ")
+}
+
+/**
+ * Resolve an opaque access token (mbt_*) to its Meeting BaaS API key.
+ * Returns null for unknown/expired tokens.
+ */
+export async function resolveAccessToken(token: string): Promise<TokenRecord | null> {
+  const raw = await getRedis().get(`oauth:token:${token}`)
+  return raw ? (JSON.parse(raw) as TokenRecord) : null
+}
+
+export function isOAuthAccessToken(token: string): boolean {
+  return token.startsWith("mbt_")
+}
+
+// ---------------------------------------------------------------------------
+// Route handlers
+// ---------------------------------------------------------------------------
+
+function handleProtectedResourceMetadata(res: ServerResponse) {
+  sendJson(res, 200, {
+    resource: `${ISSUER}/mcp`,
+    authorization_servers: [ISSUER],
+    bearer_methods_supported: ["header"],
+    scopes_supported: SCOPES,
+    resource_name: "Meeting BaaS"
+  })
+}
+
+function handleAuthServerMetadata(res: ServerResponse) {
+  sendJson(res, 200, {
+    issuer: ISSUER,
+    authorization_endpoint: `${ISSUER}/oauth/authorize`,
+    token_endpoint: `${ISSUER}/oauth/token`,
+    registration_endpoint: `${ISSUER}/oauth/register`,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    code_challenge_methods_supported: ["S256"],
+    token_endpoint_auth_methods_supported: ["none"],
+    scopes_supported: SCOPES
+  })
+}
+
+async function handleRegister(req: IncomingMessage, res: ServerResponse) {
+  if (await rateLimited(req, "register", 10)) {
+    return oauthError(res, 429, "slow_down", "Too many registration requests")
+  }
+
+  let body: Record<string, unknown>
+  try {
+    body = await readJsonBody(req)
+  } catch {
+    return oauthError(res, 400, "invalid_client_metadata", "Body must be valid JSON")
+  }
+
+  const redirectUris = body.redirect_uris
+  if (!Array.isArray(redirectUris) || redirectUris.length === 0 || !redirectUris.every((u) => typeof u === "string" && isAllowedRedirectUri(u))) {
+    return oauthError(
+      res,
+      400,
+      "invalid_redirect_uri",
+      "redirect_uris must be a non-empty array of https:// (or http://localhost) URLs"
+    )
+  }
+
+  const client: OAuthClient = {
+    client_id: randomToken("mbc"),
+    client_name: typeof body.client_name === "string" ? body.client_name.slice(0, 128) : undefined,
+    redirect_uris: redirectUris as string[],
+    token_endpoint_auth_method: "none",
+    client_id_issued_at: Math.floor(Date.now() / 1000)
+  }
+  await getRedis().set(`oauth:client:${client.client_id}`, JSON.stringify(client))
+
+  sendJson(res, 201, client)
+}
+
+async function getClient(clientId: string): Promise<OAuthClient | null> {
+  if (!clientId) return null
+  const raw = await getRedis().get(`oauth:client:${clientId}`)
+  return raw ? (JSON.parse(raw) as OAuthClient) : null
+}
+
+async function handleAuthorize(req: IncomingMessage, res: ServerResponse, url: URL) {
+  if (!CONSENT_URL) {
+    return oauthError(res, 503, "temporarily_unavailable", "OAUTH_CONSENT_URL is not configured")
+  }
+
+  const q = url.searchParams
+  const client = await getClient(q.get("client_id") || "")
+  const redirectUri = q.get("redirect_uri") || ""
+
+  // Per OAuth 2.1, never redirect to an unvalidated redirect_uri.
+  if (!client || !client.redirect_uris.includes(redirectUri)) {
+    return oauthError(res, 400, "invalid_request", "Unknown client_id or unregistered redirect_uri")
+  }
+
+  const respondRedirectError = (error: string, description: string) => {
+    const target = new URL(redirectUri)
+    target.searchParams.set("error", error)
+    target.searchParams.set("error_description", description)
+    const state = q.get("state")
+    if (state) target.searchParams.set("state", state)
+    res.writeHead(302, { Location: target.toString() }).end()
+  }
+
+  if (q.get("response_type") !== "code") {
+    return respondRedirectError("unsupported_response_type", "Only response_type=code is supported")
+  }
+  if (!q.get("code_challenge") || q.get("code_challenge_method") !== "S256") {
+    return respondRedirectError("invalid_request", "PKCE with code_challenge_method=S256 is required")
+  }
+
+  const requestedScopes = (q.get("scope") || "").split(" ").filter(Boolean)
+  const unknown = requestedScopes.filter((s) => !SCOPES.includes(s))
+  if (unknown.length > 0) {
+    return respondRedirectError("invalid_scope", `Unknown scope(s): ${unknown.join(", ")}`)
+  }
+
+  const request: AuthRequest = {
+    client_id: client.client_id,
+    redirect_uri: redirectUri,
+    code_challenge: q.get("code_challenge") as string,
+    state: q.get("state") || undefined,
+    scope: requestedScopes.length > 0 ? requestedScopes.join(" ") : SCOPES.join(" ")
+  }
+  const requestId = randomToken("mbar")
+  await getRedis().set(`oauth:req:${requestId}`, JSON.stringify(request), "EX", AUTH_REQUEST_TTL_S)
+
+  const consent = new URL(CONSENT_URL)
+  consent.searchParams.set("request_id", requestId)
+  consent.searchParams.set("client_name", client.client_name || client.client_id)
+  consent.searchParams.set("scope", request.scope)
+  res.writeHead(302, { Location: consent.toString() }).end()
+}
+
+/**
+ * Server-to-server callback from the Meeting BaaS dashboard after the user
+ * logs in and approves (or denies) the consent screen. Authenticated with the
+ * shared OAUTH_CONSENT_SECRET. Responds with the URL the dashboard should
+ * redirect the user's browser to.
+ */
+async function handleConsentComplete(req: IncomingMessage, res: ServerResponse) {
+  if (!CONSENT_SECRET) {
+    return oauthError(res, 503, "temporarily_unavailable", "OAUTH_CONSENT_SECRET is not configured")
+  }
+  const provided = req.headers["x-consent-secret"]
+  const secretOk =
+    typeof provided === "string" &&
+    provided.length === CONSENT_SECRET.length &&
+    crypto.timingSafeEqual(Buffer.from(provided), Buffer.from(CONSENT_SECRET))
+  if (!secretOk) {
+    return oauthError(res, 401, "access_denied", "Invalid consent secret")
+  }
+
+  let body: Record<string, unknown>
+  try {
+    body = await readJsonBody(req)
+  } catch {
+    return oauthError(res, 400, "invalid_request", "Body must be valid JSON")
+  }
+
+  const requestId = typeof body.request_id === "string" ? body.request_id : ""
+  const redis = getRedis()
+  const rawRequest = await redis.get(`oauth:req:${requestId}`)
+  if (!rawRequest) {
+    return oauthError(res, 400, "invalid_request", "Unknown or expired request_id")
+  }
+  const request = JSON.parse(rawRequest) as AuthRequest
+  await redis.del(`oauth:req:${requestId}`)
+
+  const redirect = new URL(request.redirect_uri)
+  if (request.state) redirect.searchParams.set("state", request.state)
+
+  if (body.approved !== true) {
+    redirect.searchParams.set("error", "access_denied")
+    return sendJson(res, 200, { redirect_url: redirect.toString() })
+  }
+
+  const apiKey = typeof body.api_key === "string" ? body.api_key : ""
+  const userId = typeof body.user_id === "string" ? body.user_id : ""
+  if (!apiKey || !userId) {
+    return oauthError(res, 400, "invalid_request", "api_key and user_id are required when approved")
+  }
+
+  const grant: CodeGrant = { ...request, api_key: apiKey, user_id: userId }
+  const code = randomToken("mbac")
+  await redis.set(`oauth:code:${code}`, JSON.stringify(grant), "EX", CODE_TTL_S)
+
+  redirect.searchParams.set("code", code)
+  sendJson(res, 200, { redirect_url: redirect.toString() })
+}
+
+async function issueTokens(res: ServerResponse, record: TokenRecord) {
+  const redis = getRedis()
+  const accessToken = randomToken("mbt")
+  const refreshToken = randomToken("mbr")
+  await redis.set(`oauth:token:${accessToken}`, JSON.stringify(record), "EX", ACCESS_TOKEN_TTL_S)
+  await redis.set(`oauth:refresh:${refreshToken}`, JSON.stringify(record), "EX", REFRESH_TOKEN_TTL_S)
+  sendJson(res, 200, {
+    access_token: accessToken,
+    token_type: "Bearer",
+    expires_in: ACCESS_TOKEN_TTL_S,
+    refresh_token: refreshToken,
+    scope: record.scope
+  })
+}
+
+async function handleToken(req: IncomingMessage, res: ServerResponse) {
+  if (await rateLimited(req, "token", 30)) {
+    return oauthError(res, 429, "slow_down", "Too many token requests")
+  }
+
+  let body: Record<string, string>
+  try {
+    body = await readFormBody(req)
+  } catch {
+    return oauthError(res, 400, "invalid_request", "Malformed request body")
+  }
+
+  const redis = getRedis()
+
+  if (body.grant_type === "authorization_code") {
+    const rawGrant = body.code ? await redis.get(`oauth:code:${body.code}`) : null
+    if (!rawGrant) {
+      return oauthError(res, 400, "invalid_grant", "Unknown or expired authorization code")
+    }
+    // Single use — delete before validating so a replay always fails.
+    await redis.del(`oauth:code:${body.code}`)
+    const grant = JSON.parse(rawGrant) as CodeGrant
+
+    if (body.client_id !== grant.client_id) {
+      return oauthError(res, 400, "invalid_grant", "client_id mismatch")
+    }
+    if (body.redirect_uri && body.redirect_uri !== grant.redirect_uri) {
+      return oauthError(res, 400, "invalid_grant", "redirect_uri mismatch")
+    }
+    if (!body.code_verifier || sha256b64url(body.code_verifier) !== grant.code_challenge) {
+      return oauthError(res, 400, "invalid_grant", "PKCE verification failed")
+    }
+
+    return issueTokens(res, {
+      api_key: grant.api_key,
+      user_id: grant.user_id,
+      client_id: grant.client_id,
+      scope: grant.scope
+    })
+  }
+
+  if (body.grant_type === "refresh_token") {
+    const rawRecord = body.refresh_token ? await redis.get(`oauth:refresh:${body.refresh_token}`) : null
+    if (!rawRecord) {
+      return oauthError(res, 400, "invalid_grant", "Unknown or expired refresh token")
+    }
+    const record = JSON.parse(rawRecord) as TokenRecord
+    if (body.client_id !== record.client_id) {
+      return oauthError(res, 400, "invalid_grant", "client_id mismatch")
+    }
+    // Rotation: old refresh token dies with this exchange.
+    await redis.del(`oauth:refresh:${body.refresh_token}`)
+    return issueTokens(res, record)
+  }
+
+  return oauthError(res, 400, "unsupported_grant_type", "Supported: authorization_code, refresh_token")
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle OAuth/metadata routes. Returns true when the request was handled,
+ * false when it should fall through to the MCP handler.
+ */
+export async function handleOAuthRoute(req: IncomingMessage, res: ServerResponse, url: URL): Promise<boolean> {
+  const path = url.pathname
+  const isOAuthPath =
+    path === "/.well-known/oauth-protected-resource" ||
+    path === "/.well-known/oauth-protected-resource/mcp" ||
+    path === "/.well-known/oauth-authorization-server" ||
+    path === "/oauth/register" ||
+    path === "/oauth/authorize" ||
+    path === "/oauth/consent/complete" ||
+    path === "/oauth/token"
+  if (!isOAuthPath) return false
+
+  if (req.method === "OPTIONS") {
+    res
+      .writeHead(204, {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type, Authorization, mcp-protocol-version"
+      })
+      .end()
+    return true
+  }
+
+  try {
+    if (path.startsWith("/.well-known/oauth-protected-resource") && req.method === "GET") {
+      handleProtectedResourceMetadata(res)
+    } else if (path === "/.well-known/oauth-authorization-server" && req.method === "GET") {
+      handleAuthServerMetadata(res)
+    } else if (path === "/oauth/register" && req.method === "POST") {
+      await handleRegister(req, res)
+    } else if (path === "/oauth/authorize" && req.method === "GET") {
+      await handleAuthorize(req, res, url)
+    } else if (path === "/oauth/consent/complete" && req.method === "POST") {
+      await handleConsentComplete(req, res)
+    } else if (path === "/oauth/token" && req.method === "POST") {
+      await handleToken(req, res)
+    } else {
+      oauthError(res, 405, "invalid_request", "Method not allowed")
+    }
+  } catch (error) {
+    console.error("OAuth route error:", error)
+    if (!res.headersSent) {
+      oauthError(res, 500, "server_error", "Internal error")
+    }
+  }
+  return true
+}

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs"
 import Redis from "ioredis"
 
 let client: Redis | null = null
@@ -6,6 +7,10 @@ let client: Redis | null = null
  * Lazy singleton Redis connection. OAuth (clients, codes, tokens, rate limits)
  * is the only consumer; the MCP session map stays in-memory. Throws if
  * REDIS_URL is unset so OAuth endpoints fail loudly instead of half-working.
+ *
+ * Managed Redis over TLS: use a rediss:// URL and, when the server uses a
+ * private CA (e.g. Scaleway), point REDIS_CA_CERT_PATH at the mounted CA
+ * certificate — same pattern as the api-server-v2 chart.
  */
 export function getRedis(): Redis {
   if (!client) {
@@ -13,7 +18,11 @@ export function getRedis(): Redis {
     if (!url) {
       throw new Error("REDIS_URL is not set — required for OAuth endpoints")
     }
-    client = new Redis(url, { maxRetriesPerRequest: 2 })
+    const caPath = process.env.REDIS_CA_CERT_PATH
+    client = new Redis(url, {
+      maxRetriesPerRequest: 2,
+      ...(url.startsWith("rediss://") && caPath ? { tls: { ca: fs.readFileSync(caPath) } } : {})
+    })
   }
   return client
 }

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -1,0 +1,19 @@
+import Redis from "ioredis"
+
+let client: Redis | null = null
+
+/**
+ * Lazy singleton Redis connection. OAuth (clients, codes, tokens, rate limits)
+ * is the only consumer; the MCP session map stays in-memory. Throws if
+ * REDIS_URL is unset so OAuth endpoints fail loudly instead of half-working.
+ */
+export function getRedis(): Redis {
+  if (!client) {
+    const url = process.env.REDIS_URL
+    if (!url) {
+      throw new Error("REDIS_URL is not set — required for OAuth endpoints")
+    }
+    client = new Redis(url, { maxRetriesPerRequest: 2 })
+  }
+  return client
+}

--- a/package.json
+++ b/package.json
@@ -21,12 +21,13 @@
   "packageManager": "pnpm@8.15.7+sha512.c85cd21b6da10332156b1ca2aa79c0a61ee7ad2eb0453b88ab299289e9e8ca93e6091232b25c07cbf61f6df77128d9c849e5c9ac6e44854dbd211c49f3a67adc",
   "dependencies": {
     "@meeting-baas/sdk": "^6.1.4",
-    "@modelcontextprotocol/sdk": "^1.10.2",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.8.4",
     "content-type": "^1.0.5",
     "dotenv": "^16.4.5",
+    "ioredis": "5.11.1",
     "raw-body": "^3.0.0",
-    "zod": "^3.24.2"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^6.1.4
     version: 6.1.4
   '@modelcontextprotocol/sdk':
-    specifier: ^1.10.2
-    version: 1.10.2
+    specifier: ^1.29.0
+    version: 1.29.0(zod@3.25.76)
   axios:
     specifier: ^1.8.4
     version: 1.8.4
@@ -20,12 +20,15 @@ dependencies:
   dotenv:
     specifier: ^16.4.5
     version: 16.4.7
+  ioredis:
+    specifier: 5.11.1
+    version: 5.11.1
   raw-body:
     specifier: ^3.0.0
     version: 3.0.0
   zod:
-    specifier: ^3.24.2
-    version: 3.24.2
+    specifier: ^3.25.76
+    version: 3.25.76
 
 devDependencies:
   '@biomejs/biome':
@@ -355,6 +358,19 @@ packages:
     dev: true
     optional: true
 
+  /@hono/node-server@1.19.14(hono@4.12.31):
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+    dependencies:
+      hono: 4.12.31
+    dev: false
+
+  /@ioredis/commands@1.10.0:
+    resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
+    dev: false
+
   /@isaacs/cliui@8.0.2:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -407,20 +423,33 @@ packages:
       - debug
     dev: false
 
-  /@modelcontextprotocol/sdk@1.10.2:
-    resolution: {integrity: sha512-rb6AMp2DR4SN+kc6L1ta2NCpApyA9WYNx3CrTSZvGxq9wH71bRur+zRqPfg0vQ9mjywR7qZdX2RGHOPq3ss+tA==}
+  /@modelcontextprotocol/sdk@1.29.0(zod@3.25.76):
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
     dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.31)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.5
       cross-spawn: 7.0.6
       eventsource: 3.0.6
-      express: 5.1.0
-      express-rate-limit: 7.5.0(express@5.1.0)
+      eventsource-parser: 3.0.1
+      express: 5.2.1
+      express-rate-limit: 8.6.0(express@5.2.1)
+      hono: 4.12.31
+      jose: 6.2.4
+      json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
       raw-body: 3.0.0
-      zod: 3.24.2
-      zod-to-json-schema: 3.24.5(zod@3.24.2)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -610,6 +639,26 @@ packages:
       negotiator: 1.0.0
     dev: false
 
+  /ajv-formats@3.0.1(ajv@8.20.0):
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+    dependencies:
+      ajv: 8.20.0
+    dev: false
+
+  /ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.4
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+    dev: false
+
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -664,19 +713,19 @@ packages:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
 
-  /body-parser@2.2.0:
-    resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
+  /body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
     dependencies:
       bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 4.4.0
-      http-errors: 2.0.0
-      iconv-lite: 0.6.3
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.14.0
-      raw-body: 3.0.0
-      type-is: 2.0.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -730,6 +779,11 @@ packages:
       readdirp: 4.1.2
     dev: true
 
+  /cluster-key-slot@1.1.1:
+    resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -770,6 +824,11 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
+  /content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+    dev: false
+
   /cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
@@ -807,9 +866,26 @@ packages:
     dependencies:
       ms: 2.1.3
 
+  /debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+    dev: false
+
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+    dev: false
+
+  /denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
     dev: false
 
   /depd@2.0.0:
@@ -933,26 +1009,31 @@ packages:
       eventsource-parser: 3.0.1
     dev: false
 
-  /express-rate-limit@7.5.0(express@5.1.0):
-    resolution: {integrity: sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==}
+  /express-rate-limit@8.6.0(express@5.2.1):
+    resolution: {integrity: sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==}
     engines: {node: '>= 16'}
     peerDependencies:
-      express: ^4.11 || 5 || ^5.0.0-beta.1
+      express: '>= 4.11'
     dependencies:
-      express: 5.1.0
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.2.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
-  /express@5.1.0:
-    resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
+  /express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.0
+      body-parser: 2.3.0
       content-disposition: 1.0.0
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
       debug: 4.4.0
+      depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -977,6 +1058,14 @@ packages:
       - supports-color
     dev: false
 
+  /fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: false
+
+  /fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+    dev: false
+
   /fdir@6.4.4(picomatch@4.0.2):
     resolution: {integrity: sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==}
     peerDependencies:
@@ -992,7 +1081,7 @@ packages:
     resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
     engines: {node: '>= 0.8'}
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.3
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -1133,6 +1222,11 @@ packages:
       function-bind: 1.1.2
     dev: false
 
+  /hono@4.12.31:
+    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
+    engines: {node: '>=16.9.0'}
+    dev: false
+
   /http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
@@ -1144,6 +1238,17 @@ packages:
       toidentifier: 1.0.1
     dev: false
 
+  /http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+    dev: false
+
   /iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -1151,8 +1256,35 @@ packages:
       safer-buffer: 2.1.2
     dev: false
 
+  /iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: false
+
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: false
+
+  /ioredis@5.11.1:
+    resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
+    engines: {node: '>=12.22.0'}
+    dependencies:
+      '@ioredis/commands': 1.10.0
+      cluster-key-slot: 1.1.1
+      debug: 4.4.3
+      denque: 2.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
     dev: false
 
   /ipaddr.js@1.9.1:
@@ -1180,10 +1312,22 @@ packages:
       '@pkgjs/parseargs': 0.11.0
     dev: true
 
+  /jose@6.2.4:
+    resolution: {integrity: sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==}
+    dev: false
+
   /joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
     dev: true
+
+  /json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+    dev: false
+
+  /json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+    dev: false
 
   /lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -1391,6 +1535,14 @@ packages:
       side-channel: 1.1.0
     dev: false
 
+  /qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+    dev: false
+
   /range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -1406,10 +1558,37 @@ packages:
       unpipe: 1.0.0
     dev: false
 
+  /raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
+    dev: false
+
   /readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
     dev: true
+
+  /redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+    dependencies:
+      redis-errors: 1.2.0
+    dev: false
+
+  /require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -1450,7 +1629,7 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.3
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -1471,7 +1650,7 @@ packages:
     resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
     engines: {node: '>= 18'}
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.3
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -1520,6 +1699,14 @@ packages:
       object-inspect: 1.13.4
     dev: false
 
+  /side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+    dev: false
+
   /side-channel-map@1.0.1:
     resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
     engines: {node: '>= 0.4'}
@@ -1552,6 +1739,17 @@ packages:
       side-channel-weakmap: 1.0.2
     dev: false
 
+  /side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+    dev: false
+
   /signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -1564,8 +1762,17 @@ packages:
       whatwg-url: 7.1.0
     dev: true
 
+  /standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+    dev: false
+
   /statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
     dev: false
 
@@ -1712,6 +1919,15 @@ packages:
       mime-types: 3.0.2
     dev: false
 
+  /type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+    dev: false
+
   /typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
@@ -1773,14 +1989,18 @@ packages:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: false
 
-  /zod-to-json-schema@3.24.5(zod@3.24.2):
-    resolution: {integrity: sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==}
+  /zod-to-json-schema@3.25.2(zod@3.25.76):
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
-      zod: ^3.24.1
+      zod: ^3.25.28 || ^4
     dependencies:
-      zod: 3.24.2
+      zod: 3.25.76
     dev: false
 
   /zod@3.24.2:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
+    dev: false
+
+  /zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
     dev: false


### PR DESCRIPTION
## Summary

Makes this server listable in the **ChatGPT Apps directory** and **Claude connectors directory** (plus Claude Code plugins and plain-MCP clients like Codex CLI). Plan in `docs/MARKETPLACE-PLAN.md`.

### Tools migration (efe4f2d)
- `@modelcontextprotocol/sdk` 1.10 → 1.29, zod → 3.25 (SDK requires the `zod/v3` subpath — old zod crashed at boot)
- All 53 tools (13 v1, 40 v2) migrated from legacy `server.tool()` (broken type inference under 1.29) to `registerTool` with titles + MCP annotations:
  - `readOnlyHint` on get*/list*
  - `destructiveHint + idempotentHint` on delete*/leave*
  - `openWorldHint` on createBot / joinMeeting
- `echo` test tool removed (directory review hygiene). No casts needed.

### OAuth 2.1 authorization server (7b478a5)
Per the MCP authorization spec:
- RFC 9728 protected-resource metadata + RFC 8414 AS metadata
- RFC 7591 dynamic client registration (public clients, PKCE only)
- Authorization code + PKCE S256, single-use codes, refresh-token rotation, per-IP rate limits
- Consent delegated to the meetingbaas.com dashboard: `/oauth/authorize` parks the request in Redis → redirects to `OAUTH_CONSENT_URL`; dashboard backend POSTs `/oauth/consent/complete` (shared secret) with the user's API key → receives the browser redirect URL
- Opaque `mbt_*` access tokens map to the user's Meeting BaaS API key in Redis — tools layer unchanged, revocation = key delete
- MCP handler: Bearer `mbt_*` resolves via Redis (those sessions default to **v2** tools); legacy API-key headers unchanged; missing/invalid credentials → **401 + `WWW-Authenticate`** (spec-required for client discovery)
- Server identity → "Meeting BaaS" 1.0.0

## Verification
Local server + Redis, end-to-end: DCR → authorize redirect → consent complete → token exchange → Bearer MCP initialize → tools/list (40 v2 tools, annotations present, no echo). Negative paths: code replay rejected, wrong PKCE verifier rejected, rotated-away refresh token rejected, forged `mbt_` → 401 `invalid_token`, no-credential POST /mcp → 401 with resource-metadata challenge. Legacy header auth verified working.

## Breaking change
POST /mcp with **no credentials at all** now returns 401 (previously initialized a keyless session that failed per tool call). Anything sending an API key header is unaffected.

## Not in this PR (blockers for submission)
- Dashboard consent page + server-to-server `/oauth/consent/complete` caller (cross-repo)
- Public privacy policy URL
- OpenAI identity verification + directory submissions
- ChatGPT embedded UI component (v1.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)